### PR TITLE
Update eufy-robovac version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Homebridge support for Eufy RoboVac",
   "main": "dist/index.js",
   "dependencies": {
-    "eufy-robovac": "^1.1.0"
+    "eufy-robovac": "^1.2.0"
   },
   "devDependencies": {
     "@types/node": "^12.0.2",


### PR DESCRIPTION
closes https://github.com/joshstrange/homebridge-eufy-robovac/issues/3

If I remember correctly (it was a while ago), this has the latest versions of the tuya firmware supported. I made this change manually a while ago and has been working reasonably since.